### PR TITLE
HMA-12175 - save incoming event timestamp

### DIFF
--- a/app/uk/gov/hmrc/mobileaudit/controllers/DataEventBuilder.scala
+++ b/app/uk/gov/hmrc/mobileaudit/controllers/DataEventBuilder.scala
@@ -19,6 +19,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions.*
 import uk.gov.hmrc.play.audit.model.DataEvent
 
+import java.time.Instant
+
 object DataEventBuilder {
   val ninoKey = "nino"
   val defaultTransactionName = "explicitAuditEvent"
@@ -32,10 +34,12 @@ object DataEventBuilder {
     val transactionName: String = incomingEvent.transactionName.getOrElse(defaultTransactionName)
     val path: String = incomingEvent.path.getOrElse(incomingEvent.auditType)
     val detail = incomingEvent.detail
+    val generatedAt = incomingEvent.generatedAt.map(_.toInstant).getOrElse(Instant.now())
 
     DataEvent(
       auditSource,
       incomingEvent.auditType,
+      generatedAt = generatedAt,
       // The `toAuditTags` adds a bunch of standard values from the header carrier
       tags = hc.toAuditTags(transactionName, path),
       // At the time of writing, `toAuditDetails` does nothing other than rebuild this list of key/value pairs

--- a/it/uk/gov/hmrc/mobileaudit/AuditManyISpec.scala
+++ b/it/uk/gov/hmrc/mobileaudit/AuditManyISpec.scala
@@ -20,42 +20,33 @@ import ch.qos.logback.classic.Level
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.scalatest.OptionValues
 import play.api.Logger
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json.*
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.mobileaudit.controllers.{IncomingAuditEvent, IncomingAuditEvents, LiveAuditController}
 import uk.gov.hmrc.mobileaudit.stubs.{AuditStub, AuthStub}
 import uk.gov.hmrc.mobileaudit.utils.BaseISpec
-import uk.gov.hmrc.play.audit.model.DataEvent
-import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
-import play.api.libs.ws.writeableOf_JsValue
-import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 
-import java.time.Instant
+import java.time.{Clock, Instant, ZoneOffset, ZonedDateTime}
 import scala.jdk.CollectionConverters.*
 
 class AuditManyISpec extends BaseISpec with OptionValues {
 
-  implicit val readDataEvent: Reads[DataEvent] = (
-    (JsPath \ "auditSource").read[String] and
-    (JsPath \ "auditType").read[String] and
-    (JsPath \ "eventId").read[String] and
-    (JsPath \ "detail").read[Map[String, String]]
-  )((auditSource, auditType, eventId, detail) =>
-    DataEvent(auditSource, auditType, eventId, Map.empty, detail, Instant.now())
-  )
-
+  val clock = Clock.fixed(Instant.parse("2026-07-30T12:00:00.000Z"), ZoneOffset.UTC)
   val authNino      = "AA100000Z"
   val maliciousNIno = "OTHERNINO"
   val authorisationJsonHeader: (String, String) = "AUTHORIZATION" -> "Bearer 123"
 
   "when multiple events are sent to /audit-events" - {
+
     "they should all be forwarded to the audit service" in {
 
       val detail = Map("nino" -> authNino)
+      val generatedAt = ZonedDateTime.now(clock)
 
       val incomingEvents = (0 to 3).map { i =>
-        IncomingAuditEvent(s"$auditType-$i", None, None, None, detail)
+        IncomingAuditEvent(s"$auditType-$i", Some(generatedAt), None, None, detail)
       }.toList
+
       val auditSource = app.configuration.underlying.getString("auditSource")
 
       AuthStub.userIsLoggedIn(authNino)
@@ -83,6 +74,7 @@ class AuditManyISpec extends BaseISpec with OptionValues {
       dataEvents.foreach { dataEvent =>
         (dataEvent \ "auditSource").as[String]     shouldBe auditSource
         (dataEvent \ "detail" \ "nino").as[String] shouldBe authNino
+        (dataEvent \ "generatedAt").as[ZonedDateTime] shouldBe generatedAt
       }
 
       // Cross-check that each of the unique audit-type values from the incoming events are present
@@ -138,6 +130,8 @@ class AuditManyISpec extends BaseISpec with OptionValues {
       val response = await(wsUrl(auditEventsUrl).post(Json.toJson(IncomingAuditEvents(incomingEvents))))
       response.status shouldBe 400
       response.body.toString shouldBe "Invalid details payload"
+
+      verifyAuditEventWasNotForwarded()
     }
 
     "it should fail if the list of events is empty" in {
@@ -149,6 +143,8 @@ class AuditManyISpec extends BaseISpec with OptionValues {
       val response = await(wsUrl(auditEventsUrl).post(Json.parse("""{"events": []}""")))
       response.status shouldBe 400
       response.body.toString   shouldBe "Invalid details payload"
+
+      verifyAuditEventWasNotForwarded()
     }
 
     "it should fail if the journeyId is not supplied as a query parameter" in {
@@ -166,6 +162,8 @@ class AuditManyISpec extends BaseISpec with OptionValues {
       val response = await(wsUrl("/audit-events").post(Json.toJson(IncomingAuditEvents(incomingEvents))))
       response.status shouldBe 400
       response.body.toString   shouldBe "{\"statusCode\":400,\"message\":\"Missing parameter: journeyId\"}"
+
+      verifyAuditEventWasNotForwarded()
     }
 
     "it should return 400 with an invalid journeyId" in {
@@ -184,6 +182,8 @@ class AuditManyISpec extends BaseISpec with OptionValues {
         wsUrl("/audit-events?journeyId=ThisIsAnInvalidJourneyId").post(Json.toJson(IncomingAuditEvents(incomingEvents)))
       )
       response.status shouldBe 400
+
+      verifyAuditEventWasNotForwarded()
     }
 
     "it should fail if the user is not logged in" in {
@@ -210,6 +210,7 @@ class AuditManyISpec extends BaseISpec with OptionValues {
             .startsWith("Authorisation failure [Bearer token not supplied]")
         )
       }
+
       verifyAuditEventWasNotForwarded()
     }
 
@@ -242,6 +243,7 @@ class AuditManyISpec extends BaseISpec with OptionValues {
             .startsWith("Authorisation failure [Insufficient ConfidenceLevel]")
         )
       }
+
       verifyAuditEventWasNotForwarded()
     }
 
@@ -288,10 +290,14 @@ class AuditManyISpec extends BaseISpec with OptionValues {
   private def verifyAuditEventsWereForwarded(count: Int): Unit =
     wireMockServer.verify(count,
                           postRequestedFor(urlPathEqualTo("/write/audit"))
-                            .withHeader("content-type", equalTo("application/json")))
+                            .withHeader("content-type", equalTo("application/json"))
+                            .withRequestBody(matchingJsonPath(s"$$.[?(@.auditSource == '${app.configuration.underlying.getString("auditSource")}')]"))
+    )
 
   private def verifyAuditEventWasNotForwarded(): Unit =
     wireMockServer.verify(0,
                           postRequestedFor(urlPathEqualTo("/write/audit"))
-                            .withHeader("content-type", equalTo("application/json")))
+                            .withHeader("content-type", equalTo("application/json"))
+                            .withRequestBody(matchingJsonPath(s"$$.[?(@.auditSource == '${app.configuration.underlying.getString("auditSource")}')]"))
+    )
 }

--- a/it/uk/gov/hmrc/mobileaudit/AuditOneISpec.scala
+++ b/it/uk/gov/hmrc/mobileaudit/AuditOneISpec.scala
@@ -16,48 +16,38 @@
 
 package uk.gov.hmrc.mobileaudit
 import ch.qos.logback.classic.Level
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent
 import org.scalatest.OptionValues
 import play.api.Logger
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
-import play.api.libs.json._
+import play.api.libs.json.*
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.mobileaudit.controllers.{IncomingAuditEvent, LiveAuditController}
 import uk.gov.hmrc.mobileaudit.stubs.{AuditStub, AuthStub}
 import uk.gov.hmrc.mobileaudit.utils.BaseISpec
-import uk.gov.hmrc.play.audit.model.DataEvent
-import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
-import play.api.libs.ws.writeableOf_JsValue
-import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 
-import java.time.Instant
-import scala.jdk.CollectionConverters._
+import java.time.{Clock, Instant, ZoneOffset, ZonedDateTime}
+import scala.jdk.CollectionConverters.*
 
 /**
-  * The unit tests check that various forms of `IncomingEvent` are correctly translated the the
+  * The unit tests check that various forms of `IncomingEvent` are correctly translated to the
   * equivalent `DataEvent`, so just do some basic sanity checks that the event that is sent matches
   * the event we generated
   */
 class AuditOneISpec extends BaseISpec with OptionValues {
 
-  implicit val readDataEvent: Reads[DataEvent] = (
-    (JsPath \ "auditSource").read[String] and
-    (JsPath \ "auditType").read[String] and
-    (JsPath \ "eventId").read[String] and
-    (JsPath \ "detail").read[Map[String, String]]
-  )((auditSource, auditType, eventId, detail) =>
-    DataEvent(auditSource, auditType, eventId, Map.empty, detail, Instant.now())
-  )
-
+  val clock = Clock.fixed(Instant.parse("2026-07-30T12:00:00.000Z"), ZoneOffset.UTC)
   val authorisationJsonHeader: (String, String) = "AUTHORIZATION" -> "Bearer 123"
 
   "when a single event sent to /audit-event" - {
+
     "it should be forwarded to the audit service" in {
       val auditSource = app.configuration.underlying.getString("auditSource")
-      val testNino    = "AA100000Z"
-      val detail      = Map("nino" -> testNino)
+      val testNino = "AA100000Z"
+      val detail = Map("nino" -> testNino)
+      val generatedAt = ZonedDateTime.now(clock)
 
-      val incomingEvent = IncomingAuditEvent(auditType, None, None, None, detail)
+      val incomingEvent = IncomingAuditEvent(auditType, Some(generatedAt), None, None, detail)
 
       AuthStub.userIsLoggedIn(testNino)
       AuditStub.respondToAuditWithNoBody
@@ -73,10 +63,12 @@ class AuditOneISpec extends BaseISpec with OptionValues {
 
       val dataEvent = Json.parse(auditRequest.getRequest.getBodyAsString.replaceAll("\\\\", ""))
 
-      (dataEvent \ "auditSource").as[String]     shouldBe auditSource
-      (dataEvent \ "auditType").as[String]       shouldBe incomingEvent.auditType
+      (dataEvent \ "auditSource").as[String] shouldBe auditSource
+      (dataEvent \ "auditType").as[String] shouldBe incomingEvent.auditType
+      (dataEvent \ "generatedAt").as[ZonedDateTime] shouldBe generatedAt
       (dataEvent \ "detail" \ "nino").as[String] shouldBe testNino
     }
+
     "it should fail if the nino in the audit body does not match that of the bearer token" in {
       val authNino      = "AA100000Z"
       val maliciousNIno = "OTHERNINO"
@@ -104,6 +96,7 @@ class AuditOneISpec extends BaseISpec with OptionValues {
 
       verifyAuditEventWasNotForwarded()
     }
+
     "it should fail if the detail section does not have a nino in the detail body" in {
       val nino   = "AA100000X"
       val detail = Map("otherKey" -> nino)
@@ -117,7 +110,10 @@ class AuditOneISpec extends BaseISpec with OptionValues {
       val response = await(wsUrl(auditEventUrl).post(Json.toJson(incomingEvent)))
       response.status shouldBe 400
       response.body.toString  shouldBe "Invalid details payload"
+
+      verifyAuditEventWasNotForwarded()
     }
+
     "it should fail if the journeyId is not supplied as a query parameter" in {
       val nino   = "AA100000X"
       val detail = Map("otherKey" -> nino)
@@ -131,6 +127,8 @@ class AuditOneISpec extends BaseISpec with OptionValues {
       val response = await(wsUrl("/audit-event").post(Json.toJson(incomingEvent)))
       response.status shouldBe 400
       response.body.toString  shouldBe "{\"statusCode\":400,\"message\":\"Missing parameter: journeyId\"}"
+
+      verifyAuditEventWasNotForwarded()
     }
 
     "it should fail if there is an unknow error in Auth" in {
@@ -140,13 +138,12 @@ class AuditOneISpec extends BaseISpec with OptionValues {
       val incomingEvent = IncomingAuditEvent(s"$auditType-1", None, None, None, detail)
 
       AuthStub.userLogInThrowsUnknownError()
-      AuditStub.respondToAuditWithNoBody
       AuditStub.respondToAuditMergedWithNoBody
 
       val response =
         await(wsUrl(auditEventUrl).addHttpHeaders(authorisationJsonHeader) post (Json.toJson(incomingEvent)))
       response.status shouldBe 500
-      response.body.toString   shouldBe "Error occurred creating audit event"
+      response.body.toString shouldBe "Error occurred creating audit event"
 
       verifyAuditEventWasNotForwarded()
     }
@@ -163,6 +160,8 @@ class AuditOneISpec extends BaseISpec with OptionValues {
 
       val response = await(wsUrl("/audit-event").post(Json.toJson(incomingEvent)))
       response.status shouldBe 400
+
+      verifyAuditEventWasNotForwarded()
     }
 
     "it should return 400 with an invalid journeyId" in {
@@ -177,17 +176,23 @@ class AuditOneISpec extends BaseISpec with OptionValues {
 
       val response = await(wsUrl("/audit-event?journeyId=ThisIsAnInvalidJourneyId").post(Json.toJson(incomingEvent)))
       response.status shouldBe 400
+
+      verifyAuditEventWasNotForwarded()
     }
   }
 
   private def verifyAuditEventWasForwarded(): Unit =
     wireMockServer.verify(1,
                           postRequestedFor(urlPathEqualTo("/write/audit"))
-                            .withHeader("content-type", equalTo("application/json")))
+                            .withHeader("content-type", equalTo("application/json"))
+                            .withRequestBody(matchingJsonPath(s"$$.[?(@.auditSource == '${app.configuration.underlying.getString("auditSource")}')]"))
+    )
 
   private def verifyAuditEventWasNotForwarded(): Unit =
     wireMockServer.verify(0,
                           postRequestedFor(urlPathEqualTo("/write/audit"))
-                            .withHeader("content-type", equalTo("application/json")))
+                          .withHeader("content-type", equalTo("application/json"))
+                          .withRequestBody(matchingJsonPath(s"$$.[?(@.auditSource == '${app.configuration.underlying.getString("auditSource")}')]"))
+    )
 
 }

--- a/test/uk/gov/hmrc/mobileaudit/services/DataEventBuilderSpec.scala
+++ b/test/uk/gov/hmrc/mobileaudit/services/DataEventBuilderSpec.scala
@@ -24,9 +24,11 @@ import org.scalatest.matchers.should.Matchers
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mobileaudit.controllers.{DataEventBuilder, IncomingAuditEvent}
 
+import java.time.{Instant, ZonedDateTime}
+
 class DataEventBuilderSpec extends AnyFreeSpecLike with Matchers with MockFactory with ScalaFutures with OptionValues {
   "when building a DataEvent" - {
-    import uk.gov.hmrc.mobileaudit.controllers.DataEventBuilder._
+    import uk.gov.hmrc.mobileaudit.controllers.DataEventBuilder.*
 
     val pathKey            = "path"
     val transactionNameKey = "transactionName"
@@ -76,6 +78,26 @@ class DataEventBuilderSpec extends AnyFreeSpecLike with Matchers with MockFactor
       val dataEvent         = buildEvent("audit-source", expectedNinoValue, incomingEvent, HeaderCarrier())
       "should be replaced with the nino value supplied to the buildEvent function" in {
         dataEvent.detail.get(ninoKey) shouldBe Some(expectedNinoValue)
+      }
+    }
+
+    "and no generatedAt is provided" - {
+      val incomingEvent = IncomingAuditEvent("audit-type", None, None, None, Map())
+      val dataEvent = buildEvent("audit-source", "nino-value", incomingEvent, HeaderCarrier())
+
+      "should default generatedAt to now" in {
+        dataEvent.generatedAt should not be (null)
+        dataEvent.generatedAt.getEpochSecond shouldBe (Instant.now().getEpochSecond +- 1)
+      }
+    }
+
+    "and generatedAt is provided" - {
+      val generatedAt = ZonedDateTime.parse("2026-07-30T12:00:00.000Z")
+      val incomingEvent = IncomingAuditEvent("audit-type", Some(generatedAt), None, None, Map())
+      val dataEvent = buildEvent("audit-source", "nino-value", incomingEvent, HeaderCarrier())
+
+      "should it should be copied to the DataEvent" in {
+        dataEvent.generatedAt shouldBe generatedAt.toInstant
       }
     }
   }


### PR DESCRIPTION
Copy generatedAt field from incoming audit data to domain model or default to now() if absent.